### PR TITLE
Split rt.jar and jce.jar import to two commands

### DIFF
--- a/globalplatform.pro
+++ b/globalplatform.pro
@@ -3,7 +3,8 @@
 -injars lib/jopt-simple-4.6.jar(!META-INF/*)
 # JNA is library because we package everything back in
 -libraryjars lib/jnasmartcardio.jar
--libraryjars  <java.home>/lib/rt.jar:<java.home>/lib/jce.jar
+-libraryjars  <java.home>/lib/rt.jar
+-libraryjars  <java.home>/lib/jce.jar
 -outjars optimized-globalplatform.jar
 -dontobfuscate
 -dontoptimize


### PR DESCRIPTION
":" path separator doesn't work in Windows 7
