### PR TITLE
Support for optional install parameters

### DIFF
--- a/src/openkms/gp/GPTool.java
+++ b/src/openkms/gp/GPTool.java
@@ -43,6 +43,7 @@ public class GPTool {
 	private final static String OPT_INSTANCE = "instance";
 	private final static String OPT_DO_ALL_READERS = "all";
 	private final static String OPT_NOFIX = "nofix";
+    private final static String OPT_PARAMS = "params";
 
 
 	private final static String OPT_CONTINUE = "skip-error";
@@ -99,6 +100,7 @@ public class GPTool {
 		parser.accepts(OPT_DELETEDEPS, "Also delete dependencies");
 		parser.accepts(OPT_REINSTALL, "Remove card content during installation");
 		parser.accepts(CMD_MAKE_DEFAULT, "Make AID the default").withRequiredArg().withValuesConvertedBy(GPToolArgumentMatchers.aid());
+        parser.accepts(OPT_PARAMS, "Use hex-encoded install parameters").withRequiredArg().withValuesConvertedBy(GPToolArgumentMatchers.installParams());
 
 		parser.accepts(CMD_DELETE, "Delete something").requiredIf(OPT_DELETEDEPS).withOptionalArg().withValuesConvertedBy(GPToolArgumentMatchers.aid());
 
@@ -123,7 +125,7 @@ public class GPTool {
 		// Key diversification and AID options
 		parser.accepts(OPT_EMV, "Use EMV diversification");
 		parser.accepts(OPT_VISA2, "Use VISA2 diversification");
-		parser.accepts(OPT_MODE, "APDU mode to use (mac/enc/clr)").withRequiredArg().withValuesConvertedBy(GPToolArgumentMatchers.mode());;
+		parser.accepts(OPT_MODE, "APDU mode to use (mac/enc/clr)").withRequiredArg().withValuesConvertedBy(GPToolArgumentMatchers.mode());
 
 		parser.accepts(OPT_SDAID, "ISD AID").withRequiredArg().withValuesConvertedBy(GPToolArgumentMatchers.aid());
 
@@ -322,7 +324,7 @@ public class GPTool {
 							}
 						}
 
-						// --install <applet.cap>
+						// --install <applet.cap> (--params <installParam>)
 						if (args.has(CMD_INSTALL)) {
 							AID def = gp.getRegistry().getDefaultSelectedPackageAID();
 							if (def != null && args.has(OPT_DEFAULT)) {
@@ -332,6 +334,7 @@ public class GPTool {
 									gp.deleteAID(def, true);
 								}
 							}
+                            InstallParams installParams = (InstallParams)args.valueOf(OPT_PARAMS);
 
 							File capfile = (File) args.valueOf(CMD_INSTALL);
 							CapFile instcap = new CapFile(new FileInputStream(capfile));
@@ -347,7 +350,7 @@ public class GPTool {
 
 							gp.verbose("Installing applet from package " + instcap.getPackageName());
 							gp.loadCapFile(instcap);
-							gp.installAndMakeSelectable(instcap.getPackageAID(), aid, null, args.has(OPT_DEFAULT) ? (byte) 0x04 : 0x00, null, null);
+							gp.installAndMakeSelectable(instcap.getPackageAID(), aid, null, args.has(OPT_DEFAULT) ? (byte) 0x04 : 0x00, installParams != null ? installParams.getParamsBytes() : null, null);
 						}
 
 						// --create <aid> (--applet <aid> --package <aid> or --cap <cap>)

--- a/src/openkms/gp/GPTool.java
+++ b/src/openkms/gp/GPTool.java
@@ -347,7 +347,7 @@ public class GPTool {
 
 							gp.verbose("Installing applet from package " + instcap.getPackageName());
 							gp.loadCapFile(instcap);
-							gp.installAndMakeSelecatable(instcap.getPackageAID(), aid, null, args.has(OPT_DEFAULT) ? (byte) 0x04 : 0x00, null, null);
+							gp.installAndMakeSelectable(instcap.getPackageAID(), aid, null, args.has(OPT_DEFAULT) ? (byte) 0x04 : 0x00, null, null);
 						}
 
 						// --create <aid> (--applet <aid> --package <aid> or --cap <cap>)
@@ -369,7 +369,7 @@ public class GPTool {
 
 							// shoot
 							AID instanceAID = (AID) args.valueOf(CMD_CREATE);
-							gp.installAndMakeSelecatable(packageAID, appletAID, instanceAID, (byte) 0x00, null, null);
+							gp.installAndMakeSelectable(packageAID, appletAID, instanceAID, (byte) 0x00, null, null);
 						}
 
 						// --list

--- a/src/openkms/gp/GPToolArgumentMatchers.java
+++ b/src/openkms/gp/GPToolArgumentMatchers.java
@@ -5,6 +5,8 @@ import joptsimple.ValueConverter;
 import openkms.gp.GlobalPlatform.APDUMode;
 import openkms.gp.KeySet.Key;
 
+import java.math.BigInteger;
+
 public class GPToolArgumentMatchers {
 
 	public static ValueConverter<AID> aid() {
@@ -84,4 +86,30 @@ public class GPToolArgumentMatchers {
 			}
 		}
 	}
+
+    public static ValueConverter<InstallParams> installParams() {
+        return new InstallParamMatcher();
+    }
+
+    public static class InstallParamMatcher implements ValueConverter<InstallParams> {
+
+        @Override
+        public Class<InstallParams> valueType() {
+            return InstallParams.class;
+        }
+
+        @Override
+        public String valuePattern() {
+            return null;
+        }
+
+        @Override
+        public InstallParams convert(String hex) {
+            try {
+                return new InstallParams(hex);
+            } catch (IllegalArgumentException e) {
+                throw new ValueConversionException(hex + " is not an hex-encoded byte array!");
+            }
+        }
+    }
 }

--- a/src/openkms/gp/GlobalPlatform.java
+++ b/src/openkms/gp/GlobalPlatform.java
@@ -634,7 +634,7 @@ public class GlobalPlatform {
 	 *            (ie. no installation parameters) if null, if non-null the
 	 *            format is {@code 0xC9 len data...}
 	 */
-	public void installAndMakeSelecatable(AID packageAID, AID appletAID, AID instanceAID, byte privileges, byte[] installParams,
+	public void installAndMakeSelectable(AID packageAID, AID appletAID, AID instanceAID, byte privileges, byte[] installParams,
 			byte[] installToken) throws GPException, CardException {
 
 		if (instanceAID == null) {

--- a/src/openkms/gp/InstallParams.java
+++ b/src/openkms/gp/InstallParams.java
@@ -1,0 +1,33 @@
+package openkms.gp;
+
+/**
+ * Installation parameters (will be in the format {@code 0xC9 00}
+ *            (ie. no installation parameters) or {@code 0xC9 len data...}
+ */
+public class InstallParams {
+
+    final private byte[] paramsBytes;
+
+    public InstallParams(String hexParams) {
+        byte[] bytes = hexStringToByteArray(hexParams);
+        paramsBytes = new byte[bytes.length + 2];
+        paramsBytes[0] = (byte)0xc9;
+        paramsBytes[1] = (byte)bytes.length;
+        System.arraycopy(bytes, 0, paramsBytes, 2, bytes.length);
+    }
+
+    public static byte[] hexStringToByteArray(String s) {
+        int len = s.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
+                    + Character.digit(s.charAt(i+1), 16));
+        }
+        return data;
+    }
+
+    public byte[] getParamsBytes() {
+        return paramsBytes;
+    }
+
+}

--- a/src/openkms/gp/InstallParams.java
+++ b/src/openkms/gp/InstallParams.java
@@ -9,21 +9,11 @@ public class InstallParams {
     final private byte[] paramsBytes;
 
     public InstallParams(String hexParams) {
-        byte[] bytes = hexStringToByteArray(hexParams);
+        byte[] bytes = GPUtils.stringToByteArray(hexParams);
         paramsBytes = new byte[bytes.length + 2];
         paramsBytes[0] = (byte)0xc9;
         paramsBytes[1] = (byte)bytes.length;
         System.arraycopy(bytes, 0, paramsBytes, 2, bytes.length);
-    }
-
-    public static byte[] hexStringToByteArray(String s) {
-        int len = s.length();
-        byte[] data = new byte[len / 2];
-        for (int i = 0; i < len; i += 2) {
-            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
-                    + Character.digit(s.charAt(i+1), 16));
-        }
-        return data;
     }
 
     public byte[] getParamsBytes() {


### PR DESCRIPTION
Hello,

This pull request adds a new --param option taking hex-encoded install parameters. Parameters are then passed to installAndMakeSelectable function.

Example:
$ java -jar gp.jar -install foobar.cap --params 01020304

I have also fixed a typo in the function name.

Thanks,