### PR TITLE
FIX: applet install parameters tag handling

### DIFF
--- a/src/pro/javacard/gp/GPTool.java
+++ b/src/pro/javacard/gp/GPTool.java
@@ -654,11 +654,11 @@ public final class GPTool {
 		if (args.has(OPT_PARAMS)) {
 			params = HexUtils.stringToBin((String) args.valueOf(OPT_PARAMS));
 			// Simple use: only application paramters without tag, prepend 0xC9
-			if (params[0] != 0xC9) {
-				byte [] newparams = new byte[params.length + 2];;
+			if (params[0] != (byte) 0xC9) {
+				byte [] newparams = new byte[params.length + 2];
 				newparams[0] = (byte) 0xC9;
 				newparams[1] = (byte) params.length;
-				System.arraycopy(newparams, 0, params, 2, params.length);
+				System.arraycopy(params, 0, newparams, 2, params.length);
 				params = newparams;
 			}
 		}


### PR DESCRIPTION
- Added cast to byte to application specific parameters tag (0xC9) in order to properly compare it with params first byte
- Corrected ArrayIndexOutOfBounds exception when executing parameter buffer handling (src and dest field in arrayCopy method were mixed up)