### PR TITLE
Allow user to override the version string

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,14 +128,11 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <executable>git</executable>
+                    <executable>sh</executable>
                     <outputFile>target/generated-resources/pro/javacard/gp/pro_version.txt</outputFile>
                     <arguments>
-                        <argument>describe</argument>
-                        <argument>--tags</argument>
-                        <argument>--always</argument>
-                        <argument>--long</argument>
-                        <argument>--dirty</argument>
+                        <argument>-c</argument>
+                        <argument>[ "x$GPPRO_VERSION" = "x" ] &amp;&amp; git describe --tags --always --long --dirty || echo "$GPPRO_VERSION"</argument>
                     </arguments>
                 </configuration>
             </plugin>


### PR DESCRIPTION
I'm sorry, this is a patch that I won't be able to test for a few days. But it should be really easy to check: basically, if it still builds, it's OK. The point I'm not sure about is the syntax of the `&&` inside maven.

Hope that helps!