### PR TITLE
Adding default behaviour when SCP version is set to any(i.e.: GPTool)

### DIFF
--- a/library/src/main/java/pro/javacard/gp/GPSession.java
+++ b/library/src/main/java/pro/javacard/gp/GPSession.java
@@ -432,7 +432,7 @@ public class GPSession {
         if ((keys.getVersion() > 0) && (scpKeyVersion != keys.getVersion())) {
             throw new GPException("Key version mismatch: " + keys.getVersion() + " != " + scpKeyVersion);
         }
-        logger.debug("Will do SCP0{}", this.scpVersion);
+        logger.debug("Will do {}", this.scpVersion);
 
         // Remove RMAC if SCP01 TODO: this should be generic sanitizer somewhere
         if (this.scpVersion == GPSecureChannel.SCP01 && securityLevel.contains(APDUMode.RMAC)) {
@@ -493,7 +493,7 @@ public class GPSession {
         byte[] host_cryptogram = null;
         if (this.scpVersion == GPSecureChannel.SCP01 || this.scpVersion == GPSecureChannel.SCP02) {
             host_cryptogram = GPCrypto.mac_3des_nulliv(sessionKeys.get(GPCardKeys.KeyPurpose.ENC), GPUtils.concatenate(card_challenge, host_challenge));
-            wrapper = new SCP0102Wrapper(sessionKeys, scpVersion, EnumSet.of(APDUMode.MAC), null, null, blockSize);
+            wrapper = new SCP0102Wrapper(sessionKeys, scpVersion, this.scpVersion, EnumSet.of(APDUMode.MAC), null, null, blockSize);
         } else {
             host_cryptogram = GPCrypto.scp03_kdf(sessionKeys.get(GPCardKeys.KeyPurpose.MAC), (byte) 0x01, cntx, 64);
             wrapper = new SCP03Wrapper(sessionKeys, scpVersion, EnumSet.of(APDUMode.MAC), null, null, blockSize);

--- a/library/src/main/java/pro/javacard/gp/SCP0102Wrapper.java
+++ b/library/src/main/java/pro/javacard/gp/SCP0102Wrapper.java
@@ -48,12 +48,11 @@ class SCP0102Wrapper extends SecureChannelWrapper {
     private boolean postAPDU = false;
 
 
-    SCP0102Wrapper(GPSessionKeys sessionKeys, int scp, EnumSet<GPSession.APDUMode> securityLevel, byte[] icv, byte[] ricv, int bs) {
-        this.blockSize = bs;
+    SCP0102Wrapper(GPSessionKeys sessionKeys, int scp, GPSecureChannel scpVersion, EnumSet<GPSession.APDUMode> securityLevel, byte[] icv, byte[] ricv, int bs) {        this.blockSize = bs;
         this.sessionKeys = sessionKeys;
         this.icv = icv;
         this.ricv = ricv;
-        setSCPVersion(scp);
+        setSCPVersion(scp, scpVersion);
         setSecurityLevel(securityLevel);
     }
 
@@ -65,11 +64,20 @@ class SCP0102Wrapper extends SecureChannelWrapper {
         return (byte) ((b | mask) & 0xFF);
     }
 
-    public void setSCPVersion(int scp) {
+    public void setSCPVersion(int scp, GPSecureChannel scpVersion) {
         // Major version of wrapper
         this.scp = 2;
-        if (scp < GPSession.SCP_02_04) {
+        if (scpVersion == GPSecureChannel.SCP01) {
             this.scp = 1;
+        }
+        
+        // Add this so in case of scp any, we define it as the most common ones:
+        // In case of SCP01 -> ICV no enc and Pre APDU
+        // In case of SCP02 -> ICV enc, and Pre APDU
+        if ((scpVersion == GPSecureChannel.SCP01) && (scp == 0)) {
+            scp = GPSession.SCP_01_05;
+        } else if ((scpVersion == GPSecureChannel.SCP02) && (scp == 0)) {
+            scp = GPSession.SCP_02_15;
         }
 
         // modes


### PR DESCRIPTION
Fixing error in library, as the SCP_ANY is passed, rest doesn't work.
Also fixed a bug that when SCP_ANY is specified, without using SCP by the card, the SCP version was being set to SCP01