### PR TITLE
GPRegistry: only have uniq entries

### DIFF
--- a/library/src/main/java/pro/javacard/gp/GPRegistry.java
+++ b/library/src/main/java/pro/javacard/gp/GPRegistry.java
@@ -49,7 +49,11 @@ public class GPRegistry implements Iterable<GPRegistryEntry> {
         if (entry.getPrivileges().has(Privilege.SecurityDomain) && entry.getType() == Kind.Application) {
             entry.setType(Kind.SecurityDomain);
         }
-        entries.add(entry);
+        if (!entries.contains(entry)) {
+            entries.add(entry);
+        } else {
+            logger.debug("Registry already contains {}", entry);
+        }
     }
 
     public Iterator<GPRegistryEntry> iterator() {

--- a/library/src/main/java/pro/javacard/gp/GPRegistryEntry.java
+++ b/library/src/main/java/pro/javacard/gp/GPRegistryEntry.java
@@ -22,10 +22,7 @@ package pro.javacard.gp;
 import apdu4j.HexUtils;
 import pro.javacard.AID;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.EnumSet;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class GPRegistryEntry {
@@ -69,6 +66,20 @@ public class GPRegistryEntry {
         if (version == null)
             return null;
         return version.clone();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof GPRegistryEntry) {
+            GPRegistryEntry o = (GPRegistryEntry) other;
+            return o.kind.equals(this.kind) && o.aid.equals(this.aid);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(aid, kind);
     }
 
     void setVersion(byte[] v) {

--- a/library/src/main/java/pro/javacard/gp/GPSession.java
+++ b/library/src/main/java/pro/javacard/gp/GPSession.java
@@ -1098,15 +1098,18 @@ public class GPSession {
         data = getConcatenatedStatus(registry, 0x40, new byte[]{0x4F, 0x00});
         registry.parse(0x40, data, Kind.Application, spec);
 
-        // Load files
-        data = getConcatenatedStatus(registry, 0x20, new byte[]{0x4F, 0x00});
-        registry.parse(0x20, data, Kind.ExecutableLoadFile, spec);
-
+        // Load files with modules is better than just load files. Registry does not allow to update
+        // existing entries
         if (spec != GPSpec.OP201) { // TODO: remove
             // Load files with modules
             data = getConcatenatedStatus(registry, 0x10, new byte[]{0x4F, 0x00});
             registry.parse(0x10, data, Kind.ExecutableLoadFile, spec);
         }
+
+        // Load files
+        data = getConcatenatedStatus(registry, 0x20, new byte[]{0x4F, 0x00});
+        registry.parse(0x20, data, Kind.ExecutableLoadFile, spec);
+
         return registry;
     }
 

--- a/library/src/main/java/pro/javacard/gp/SCP02Wrapper.java
+++ b/library/src/main/java/pro/javacard/gp/SCP02Wrapper.java
@@ -127,7 +127,7 @@ class SCP02Wrapper extends SecureChannelWrapper {
                 t.write(origData);
 
 
-                logger.debug("MAC input: {}", HexUtils.bin2hex(t.toByteArray()));
+                logger.trace("MAC input: {}", HexUtils.bin2hex(t.toByteArray()));
                 icv = GPCrypto.mac_des_3des(sessionKeys.get(MAC), t.toByteArray(), icv);
 
                 if (postAPDU) {


### PR DESCRIPTION
So that load files with modules would not be added separately and would
have better priority than just plain load files.