### PR TITLE
Improve logic for if lc should be encoded in one or three bytes

### DIFF
--- a/library/src/main/java/pro/javacard/gp/GPUtils.java
+++ b/library/src/main/java/pro/javacard/gp/GPUtils.java
@@ -114,9 +114,9 @@ public class GPUtils {
     }
 
     // Encodes APDU LC value, which has either length of 1 byte or 3 bytes (for extended length APDUs)
-    // If LC is bigger than fits in one byte (255), LC must be encoded in three bytes
-    public static byte[] encodeLcLength(int lc) {
-        if (lc > 255) {
+    // If LC or LE is bigger than fits in one byte (255), LC must be encoded in three bytes
+    public static byte[] encodeLcLength(int lc, int le) {
+        if (lc > 255 || le > 255) {
             byte[] lc_ba = ByteBuffer.allocate(4).putInt(lc).array();
             return Arrays.copyOfRange(lc_ba, 1, 4);
         } else

--- a/library/src/main/java/pro/javacard/gp/SCP03Wrapper.java
+++ b/library/src/main/java/pro/javacard/gp/SCP03Wrapper.java
@@ -82,7 +82,7 @@ class SCP03Wrapper extends SecureChannelWrapper {
                 bo.write(command.getINS());
                 bo.write(command.getP1());
                 bo.write(command.getP2());
-                bo.write(GPUtils.encodeLcLength(lc));
+                bo.write(GPUtils.encodeLcLength(lc, command.getNe()));
                 bo.write(data);
                 byte[] cmac_input = bo.toByteArray();
                 byte[] cmac = GPCrypto.scp03_mac(sessionKeys.get(GPCardKeys.KeyPurpose.MAC), cmac_input, 128);


### PR DESCRIPTION
The CommandAPDU will be output as an extended APDU if lc or le is more
than 255 bytes, this adds logic for looking at le as well.