### PR TITLE
scp03: just add 0x4 for the transmitted CLA, use 0x84 for mac

### DIFF
--- a/library/src/main/java/pro/javacard/gp/SCP03Wrapper.java
+++ b/library/src/main/java/pro/javacard/gp/SCP03Wrapper.java
@@ -56,7 +56,7 @@ class SCP03Wrapper extends SecureChannelWrapper {
 
             // Encrypt if needed
             if (enc) {
-                cla = 0x84;
+                cla |= 0x4;
                 // Counter shall always be incremented
                 GPCrypto.buffer_increment(encryption_counter);
                 if (command.getData().length > 0) {
@@ -73,12 +73,12 @@ class SCP03Wrapper extends SecureChannelWrapper {
             }
             // Calculate C-MAC
             if (mac) {
-                cla = 0x84;
+                cla |= 0x4;
                 lc = lc + 8;
 
                 ByteArrayOutputStream bo = new ByteArrayOutputStream();
                 bo.write(chaining_value);
-                bo.write(cla);
+                bo.write(0x84);
                 bo.write(command.getINS());
                 bo.write(command.getP1());
                 bo.write(command.getP2());


### PR DESCRIPTION
The transmitted CLA should keep it's original propertied but have bit 3
set. The mac CLA should still use 0x84 though.