### PR TITLE
Fix handling of large ACR lists

### DIFF
--- a/library/src/main/java/pro/javacard/gp/SEAccessControl.java
+++ b/library/src/main/java/pro/javacard/gp/SEAccessControl.java
@@ -602,16 +602,17 @@ public class SEAccessControl {
             return Arrays.copyOf(data, data.length);
         }
 
+        public void addData(final byte[] source) {
+            System.arraycopy(source, 0, data, currentIndex, source.length);
+            currentIndex += source.length;
+        }
+
         public int getLength() {
             return length;
         }
 
         public int getCurrentIndex() {
             return currentIndex;
-        }
-
-        public void setCurrentIndex(int index) {
-            this.currentIndex = index;
         }
     }
 
@@ -662,8 +663,7 @@ public class SEAccessControl {
                 System.arraycopy(data, offset, berData, 0, data.length - offset);
                 return new BerTlvData(berData, length, data.length - offset);
             } else if (previousData != null) {
-                System.arraycopy(data, 0, previousData.getData(), previousData.currentIndex, data.length);
-                previousData.setCurrentIndex(data.length + previousData.currentIndex);
+                previousData.addData(data);
                 return previousData;
             } else {
                 throw new GPDataException("ACR get data : bad response format (GET_DATA)");


### PR DESCRIPTION
If an ACR list is split over multiple responses, `AcrListResponse#getAcrListData` uses `BerTlvData#getData` to get the array extra responses after the first should be copied into. However, since `BerTlvData#getData` returns a copy of the array and not the actual array, the copies have no effect.

Fix by implementing `BerTlvData#addData`, which copies data to the correct position and increments the index pointer in one go, and adjust `AcrListResponse#getAcrListData` to use it.

Also, remove `BerTlvData#setCurrentIndex` so that the atomic `BerTlvData#addData` must be used instead.

Before:

```
RULE #0 :
       AID  : FFFFFFFFFFFF
       HASH : 61ED377E85D386A8DFEE6B864BD85B0BFAA5AF81
       APDU rule   : ALWAYS(0x01)
RULE #1 :
       APDU rule   : ALWAYS(0x01)
RULE #2 :
       AID  : A000000476416E64726F696443545340
       APDU rule   : NEVER(0x00)
RULE #3 :
       AID  : A000000476416E64726F696443545341
       APDU rule   : NEVER(0x00)
RULE #4 :
       AID  : A000000476416E64726F696443545342
       APDU rule   : NEVER(0x00)
RULE #5 :
       AID  : A000000476416E64726F696443545343
       APDU rule   : NEVER(0x00)
RULE #6 :
       AID  : A000000476416E64726F696443545344
       APDU rule   : NEVER(0x00)
RULE #7 :
       AID  : A000000476416E64726F696443545345
       APDU rule   : NEVER(0x00)
RULE #8 :
       AID  : A000000476416E647200000000000000
```

After:

```
RULE #0 :
       AID  : FFFFFFFFFFFF
       HASH : 61ED377E85D386A8DFEE6B864BD85B0BFAA5AF81
       APDU rule   : ALWAYS(0x01)
RULE #1 :
       APDU rule   : ALWAYS(0x01)
RULE #2 :
       AID  : A000000476416E64726F696443545340
       APDU rule   : NEVER(0x00)
RULE #3 :
       AID  : A000000476416E64726F696443545341
       APDU rule   : NEVER(0x00)
RULE #4 :
       AID  : A000000476416E64726F696443545342
       APDU rule   : NEVER(0x00)
RULE #5 :
       AID  : A000000476416E64726F696443545343
       APDU rule   : NEVER(0x00)
RULE #6 :
       AID  : A000000476416E64726F696443545344
       APDU rule   : NEVER(0x00)
RULE #7 :
       AID  : A000000476416E64726F696443545345
       APDU rule   : NEVER(0x00)
RULE #8 :
       AID  : A000000476416E64726F696443545346
       APDU rule   : NEVER(0x00)
RULE #9 :
       AID  : A000000476416E64726F696443545347
       APDU rule   : NEVER(0x00)
RULE #10 :
       AID  : A000000476416E64726F696443545348
       APDU rule   : NEVER(0x00)
(... omitted ...)
RULE #39 :
       AID  : A000000476416E64726F696443545345
       HASH : 5528CA826DA49D0D7329F8117481CCB27B8833AA
       APDU rule   : ALWAYS(0x01)
RULE #40 :
       AID  : A000000476416E64726F696443545346
       HASH : 5528CA826DA49D0D7329F8117481CCB27B8833AA
       APDU rule   : ALWAYS(0x01)
```