### PR TITLE
delete key takes a TLV, not just tag + value

### DIFF
--- a/library/src/main/java/pro/javacard/gp/GPSession.java
+++ b/library/src/main/java/pro/javacard/gp/GPSession.java
@@ -889,6 +889,7 @@ public class GPSession {
         //bo.write(0xd0);
         //bo.write(1);
         bo.write(0xd2);
+        bo.write(1); // length
         bo.write(keyver);
 
 //		bo.write(0xd0);


### PR DESCRIPTION
this is specified in 11.2.2 of the Card Specification v2.3.1