### PR TITLE
when checking if an apdu is extended check if le > 256

### DIFF
--- a/library/src/main/java/pro/javacard/gp/GPUtils.java
+++ b/library/src/main/java/pro/javacard/gp/GPUtils.java
@@ -116,7 +116,7 @@ public class GPUtils {
     // Encodes APDU LC value, which has either length of 1 byte or 3 bytes (for extended length APDUs)
     // If LC or LE is bigger than fits in one byte (255), LC must be encoded in three bytes
     public static byte[] encodeLcLength(int lc, int le) {
-        if (lc > 255 || le > 255) {
+        if (lc > 255 || le > 256) {
             byte[] lc_ba = ByteBuffer.allocate(4).putInt(lc).array();
             return Arrays.copyOfRange(lc_ba, 1, 4);
         } else


### PR DESCRIPTION
apdu4j uses that definition for how to encode it

Unfortunately this got broken in #180 