### PR TITLE
Fixes and keys

### DIFF
--- a/library/src/main/java/pro/javacard/gp/GPSession.java
+++ b/library/src/main/java/pro/javacard/gp/GPSession.java
@@ -1013,7 +1013,7 @@ public class GPSession {
 
 
     // Puts a RSA public key for DAP purposes (format 1)
-    public void putKey(RSAPublicKey pubkey, int version) throws IOException, GPException {
+    public void putKey(RSAPublicKey pubkey, int version, boolean replace) throws IOException, GPException {
         ByteArrayOutputStream bo = new ByteArrayOutputStream();
 
         try {
@@ -1031,13 +1031,13 @@ public class GPSession {
             throw new RuntimeException(e);
         }
 
-        CommandAPDU command = new CommandAPDU(CLA_GP, INS_PUT_KEY, 0x00, 0x01, bo.toByteArray());
+        CommandAPDU command = new CommandAPDU(CLA_GP, INS_PUT_KEY, replace ? version : 0x00, 0x01, bo.toByteArray());
         ResponseAPDU response = transmit(command);
         GPException.check(response, "PUT KEY failed");
     }
 
     // Puts an EC public key for DAP purposes FIXME: P-256
-    public void putKey(ECPublicKey pubkey, int version) throws IOException, GPException {
+    public void putKey(ECPublicKey pubkey, int version, boolean replace) throws IOException, GPException {
         ByteArrayOutputStream bo = new ByteArrayOutputStream();
 
         try {
@@ -1054,11 +1054,10 @@ public class GPSession {
             throw new RuntimeException(e);
         }
 
-        CommandAPDU command = new CommandAPDU(CLA_GP, INS_PUT_KEY, 0x00, 0x01, bo.toByteArray());
+        CommandAPDU command = new CommandAPDU(CLA_GP, INS_PUT_KEY, replace ? version : 0x00, 0x01, bo.toByteArray());
         ResponseAPDU response = transmit(command);
         GPException.check(response, "PUT KEY failed");
     }
-
 
     public GPRegistry getRegistry() throws GPException, IOException {
         if (dirty) {

--- a/library/src/main/java/pro/javacard/gp/GPSession.java
+++ b/library/src/main/java/pro/javacard/gp/GPSession.java
@@ -1059,6 +1059,26 @@ public class GPSession {
         GPException.check(response, "PUT KEY failed");
     }
 
+    // Puts a 3DES key
+    public void putKey(byte[] key, int version, boolean replace) throws IOException, GPException {
+        ByteArrayOutputStream bo = new ByteArrayOutputStream();
+
+	PlaintextKeys newKey = PlaintextKeys.fromMasterKey(key);
+	newKey.scp = GPSecureChannel.SCP02;
+	byte[] cgram = encodeKey(sessionKeys, newKey, KeyPurpose.DEK);
+
+        try {
+            bo.write(version); // key Version number
+	    bo.write(cgram);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        CommandAPDU command = new CommandAPDU(CLA_GP, INS_PUT_KEY, replace ? version : 0x00, 0x01, bo.toByteArray());
+        ResponseAPDU response = transmit(command);
+        GPException.check(response, "PUT KEY failed");
+    }
+
     public GPRegistry getRegistry() throws GPException, IOException {
         if (dirty) {
             registry = getStatus();

--- a/library/src/main/java/pro/javacard/gp/GPUtils.java
+++ b/library/src/main/java/pro/javacard/gp/GPUtils.java
@@ -139,8 +139,9 @@ public class GPUtils {
 
     static void trace_lv(byte[] data, Logger l) {
         for (int i = 0; i < data.length; ) {
-            l.trace(String.format("[%02X] %s", data[i] & 0xFF, HexUtils.bin2hex(Arrays.copyOfRange(data, i + 1, i + 1 + data[i]))));
-            i += 1 + data[i];
+            int d = data[i] & 0xFF;
+            l.trace(String.format("[%02X] %s", d, HexUtils.bin2hex(Arrays.copyOfRange(data, i + 1, i + 1 + d))));
+            i += 1 + d;
         }
     }
 

--- a/tool/src/main/java/pro/javacard/gp/GPCommandLineInterface.java
+++ b/tool/src/main/java/pro/javacard/gp/GPCommandLineInterface.java
@@ -76,9 +76,11 @@ abstract class GPCommandLineInterface {
     protected final static String OPT_PARAMS = "params";
     protected final static String OPT_PRIVS = "privs";
     protected final static String OPT_PUT_KEY = "put-key";
+    protected final static String OPT_PUT_3DES_KEY = "put-3des-key";
     protected final static String OPT_READER = "reader";
     protected final static String OPT_RENAME_ISD = "rename-isd";
     protected final static String OPT_REPLACE_KEY = "replace-key";
+    protected final static String OPT_REPLACE_3DES_KEY = "replace-3des-key";
     protected final static String OPT_SC_MODE = "mode";
     protected final static String OPT_SDAID = "sdaid";
     protected final static String OPT_SECURE_APDU = "secure-apdu";
@@ -189,6 +191,8 @@ abstract class GPCommandLineInterface {
         parser.accepts(OPT_KEY_VERSION, "Specify key version").withRequiredArg();
         parser.accepts(OPT_PUT_KEY, "Put a new key").withRequiredArg().describedAs("PEM file");
         parser.accepts(OPT_REPLACE_KEY, "Replace a key").withRequiredArg().describedAs("PEM file");
+        parser.accepts(OPT_PUT_3DES_KEY, "Put a new 3DES key").withRequiredArg().describedAs("key");
+        parser.accepts(OPT_REPLACE_3DES_KEY, "Replace a 3DES key").withRequiredArg().describedAs("key");
 
         parser.accepts(OPT_LOCK, "Set new key").withRequiredArg().describedAs("key");
         parser.accepts(OPT_LOCK_KDF, "Use KDF with lock key").withRequiredArg().describedAs("kdf");

--- a/tool/src/main/java/pro/javacard/gp/GPCommandLineInterface.java
+++ b/tool/src/main/java/pro/javacard/gp/GPCommandLineInterface.java
@@ -78,6 +78,7 @@ abstract class GPCommandLineInterface {
     protected final static String OPT_PUT_KEY = "put-key";
     protected final static String OPT_READER = "reader";
     protected final static String OPT_RENAME_ISD = "rename-isd";
+    protected final static String OPT_REPLACE_KEY = "replace-key";
     protected final static String OPT_SC_MODE = "mode";
     protected final static String OPT_SDAID = "sdaid";
     protected final static String OPT_SECURE_APDU = "secure-apdu";
@@ -187,6 +188,7 @@ abstract class GPCommandLineInterface {
         parser.accepts(OPT_KEY_ID, "Specify key ID").withRequiredArg();
         parser.accepts(OPT_KEY_VERSION, "Specify key version").withRequiredArg();
         parser.accepts(OPT_PUT_KEY, "Put a new key").withRequiredArg().describedAs("PEM file");
+        parser.accepts(OPT_REPLACE_KEY, "Replace a key").withRequiredArg().describedAs("PEM file");
 
         parser.accepts(OPT_LOCK, "Set new key").withRequiredArg().describedAs("key");
         parser.accepts(OPT_LOCK_KDF, "Use KDF with lock key").withRequiredArg().describedAs("kdf");

--- a/tool/src/main/java/pro/javacard/gp/GPTool.java
+++ b/tool/src/main/java/pro/javacard/gp/GPTool.java
@@ -371,6 +371,25 @@ public final class GPTool extends GPCommandLineInterface {
                     }
                 }
 
+                // --put-des-key <key>
+                // --replace-des-key <key>
+                if (args.has(OPT_PUT_3DES_KEY) || args.has(OPT_REPLACE_3DES_KEY)) {
+		    boolean replace;
+                    byte[] key;
+		    if (args.has(OPT_PUT_3DES_KEY)) {
+		        replace = false;
+                        key = HexUtils.stringToBin((String) args.valueOf(OPT_PUT_3DES_KEY));
+		    } else {
+		        replace = true;
+                        key = HexUtils.stringToBin((String) args.valueOf(OPT_REPLACE_3DES_KEY));
+		    }
+                    int keyVersion = 0x73; // Default DAP version
+                    if (args.has(OPT_NEW_KEY_VERSION)) {
+                        keyVersion = GPUtils.intValue(args.valueOf(OPT_NEW_KEY_VERSION).toString());
+                    }
+                    gp.putKey(key, keyVersion, replace);
+                }
+
                 // --install <applet.cap> (--applet <aid> --create <aid> --privs <privs> --params <params>)
                 if (args.has(OPT_INSTALL)) {
                     final File capfile;
@@ -864,7 +883,7 @@ public final class GPTool extends GPCommandLineInterface {
                 OPT_ACR_ADD, OPT_ACR_DELETE, OPT_LOCK, OPT_UNLOCK, OPT_LOCK_ENC, OPT_LOCK_MAC, OPT_LOCK_DEK, OPT_MAKE_DEFAULT,
                 OPT_UNINSTALL, OPT_SECURE_APDU, OPT_DOMAIN, OPT_LOCK_CARD, OPT_UNLOCK_CARD, OPT_LOCK_APPLET, OPT_UNLOCK_APPLET,
                 OPT_STORE_DATA, OPT_STORE_DATA_CHUNK, OPT_INITIALIZE_CARD, OPT_SECURE_CARD, OPT_RENAME_ISD, OPT_SET_PERSO, OPT_SET_PRE_PERSO, OPT_MOVE,
-                OPT_PUT_KEY, OPT_REPLACE_KEY, OPT_ACR_AID, OPT_ACR_LIST};
+                OPT_PUT_KEY, OPT_REPLACE_KEY, OPT_PUT_3DES_KEY, OPT_REPLACE_3DES_KEY, OPT_ACR_AID, OPT_ACR_LIST};
 
         return Arrays.stream(yes).anyMatch(str -> args.has(str));
     }

--- a/tool/src/main/java/pro/javacard/gp/GPTool.java
+++ b/tool/src/main/java/pro/javacard/gp/GPTool.java
@@ -341,20 +341,30 @@ public final class GPTool extends GPCommandLineInterface {
                 }
 
                 // --put-key <keyfile.pem>
-                // Load a public key (for DAP purposes)
-                if (args.has(OPT_PUT_KEY)) {
+                // --replace-key <keyfile.pem>
+                // Load/change a public key (for DAP purposes)
+                if (args.has(OPT_PUT_KEY) || args.has(OPT_REPLACE_KEY)) {
+		    boolean replace;
+		    String keyFile;
+		    if (args.has(OPT_PUT_KEY)) {
+		        replace = false;
+		        keyFile = args.valueOf(OPT_PUT_KEY).toString();
+		    } else {
+		        replace = true;
+		        keyFile = args.valueOf(OPT_REPLACE_KEY).toString();
+		    }
                     int keyVersion = 0x73; // Default DAP version
                     if (args.has(OPT_NEW_KEY_VERSION)) {
                         keyVersion = GPUtils.intValue(args.valueOf(OPT_NEW_KEY_VERSION).toString());
                     }
 
-                    try (FileInputStream fin = new FileInputStream(new File(args.valueOf(OPT_PUT_KEY).toString()))) {
+                    try (FileInputStream fin = new FileInputStream(new File(keyFile))) {
                         // Get public key
                         PublicKey key = GPCrypto.pem2PublicKey(fin);
                         if (key instanceof RSAPublicKey) {
-                            gp.putKey((RSAPublicKey) key, keyVersion);
+                            gp.putKey((RSAPublicKey) key, keyVersion, replace);
                         } else if (key instanceof ECPublicKey) {
-                            gp.putKey((ECPublicKey) key, keyVersion);
+                            gp.putKey((ECPublicKey) key, keyVersion, replace);
                         } else {
                             fail("Unknown key type: " + key.getAlgorithm());
                         }
@@ -854,7 +864,7 @@ public final class GPTool extends GPCommandLineInterface {
                 OPT_ACR_ADD, OPT_ACR_DELETE, OPT_LOCK, OPT_UNLOCK, OPT_LOCK_ENC, OPT_LOCK_MAC, OPT_LOCK_DEK, OPT_MAKE_DEFAULT,
                 OPT_UNINSTALL, OPT_SECURE_APDU, OPT_DOMAIN, OPT_LOCK_CARD, OPT_UNLOCK_CARD, OPT_LOCK_APPLET, OPT_UNLOCK_APPLET,
                 OPT_STORE_DATA, OPT_STORE_DATA_CHUNK, OPT_INITIALIZE_CARD, OPT_SECURE_CARD, OPT_RENAME_ISD, OPT_SET_PERSO, OPT_SET_PRE_PERSO, OPT_MOVE,
-                OPT_PUT_KEY, OPT_ACR_AID, OPT_ACR_LIST};
+                OPT_PUT_KEY, OPT_REPLACE_KEY, OPT_ACR_AID, OPT_ACR_LIST};
 
         return Arrays.stream(yes).anyMatch(str -> args.has(str));
     }


### PR DESCRIPTION
The following patches implement what's needed here to be able to load applets into a Delegated Management SSD: make able to replace a token RSA key (0x70), make able to put or replace a receipt 3DES key (0x71).

After applying those patches I'm able to successfully load applets into my card using:

ISDKEYS="--key-enc XXX --key-mac XXX --key-dek XXX"
openssl genrsa 1024 > key.pem
gp --sdaid A000000151000000 $ISDKEYS --replace-key key.pem --new-keyver 0x70 --key-id 0x01
DESKEY=$(openssl rand -hex 16)
gp --sdaid A000000151000000 $ISDKEYS --replace-3des-key $DESKEY --new-keyver 0x71 --key-id 0x01
gp --sdaid A000000151000000 $ISDKEYS --domain A000000004000001 --privs DelegatedManagement
gp --sdaid A000000151000000 $ISDKEYS --lock f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2
gp --sdaid A000000004000001 --key f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2f2 --install hello.cap --token-key key.pem --sha256

