### PR TITLE
APDU Lc encoding for Le == 256 edge case

### DIFF
--- a/library/src/main/java/pro/javacard/gp/GPUtils.java
+++ b/library/src/main/java/pro/javacard/gp/GPUtils.java
@@ -116,7 +116,7 @@ public class GPUtils {
     // Encodes APDU LC value, which has either length of 1 byte or 3 bytes (for extended length APDUs)
     // If LC or LE is bigger than fits in one byte (255), LC must be encoded in three bytes
     public static byte[] encodeLcLength(int lc, int le) {
-        if (lc > 255 || le > 255) {
+        if (lc > 255 || le > 256) {
             byte[] lc_ba = ByteBuffer.allocate(4).putInt(lc).array();
             return Arrays.copyOfRange(lc_ba, 1, 4);
         } else


### PR DESCRIPTION
I believe that the proper Le coding for 256 is single byte standard form as 0x00 and that the Lc coding would not be altered to the three byte form for the edge case of Le == 256.

Interestingly, I saw code in apdu4j that dances around the same edge case.

The extant code caused me some difficulties with a certain NXP product in SCP03 mode.