### PR TITLE
In SCP03Wrapper R-APDU Unwrap doubles SW1 SW2

### DIFF
--- a/library/src/main/java/pro/javacard/gp/SCP03Wrapper.java
+++ b/library/src/main/java/pro/javacard/gp/SCP03Wrapper.java
@@ -145,7 +145,7 @@ class SCP03Wrapper extends SecureChannelWrapper {
                 }
 
                 ByteArrayOutputStream o = new ByteArrayOutputStream();
-                o.write(response.getBytes(), 0, respLen);
+                o.write(response.getData(), 0, respLen);
                 o.write(response.getSW1());
                 o.write(response.getSW2());
                 response = new ResponseAPDU(o.toByteArray());


### PR DESCRIPTION
I think response.getData() was desired instead of response.getBytes().