### PR TITLE
In SCP03Wrapper, handle R-APDUs with error status words per spec.

### DIFF
--- a/library/src/main/java/pro/javacard/gp/SCP03Wrapper.java
+++ b/library/src/main/java/pro/javacard/gp/SCP03Wrapper.java
@@ -120,10 +120,10 @@ class SCP03Wrapper extends SecureChannelWrapper {
         try {
             if (rmac) {
                 if (response.getData().length < 8) {
-                    // Per GP 2.2, Amendment D, v1.1.1(+), all non-error R-APDUs must have a MAC.
+                    // Per GP 2.2, Amendment D, v1.1.1(+), section 6.2.5, all non-error R-APDUs must have a MAC.
                     // R-APDUs representing an error status shall not have a data segment or MAC.
-                    if ( ( (response.getSW1() == 0x90) && (response.getSW2() == 0x00) ) || (response.getSW1() == 0x62) || (response.getSW2() == 0x63) ) {
-                        // These are the statuses considered non-error by said section of the spec.
+                    if ( (response.getSW() == 0x9000) || (response.getSW1() == 0x62) || (response.getSW1() == 0x63) ) {
+                        // These are the statuses considered non-error by section 6.2.5 of the spec.
                         // As we can not have a MAC, throw exception.
                         throw new GPException("Received R-APDU without authentication data in RMAC session.");
                     }


### PR DESCRIPTION
Global Platform Card Specifications 2.2, Amendment D, versions 1.1.1 and higher specify in section 6.2.5:

"No R-MAC shall be generated and no protection shall be applied to a response that includes an error status word: in this case only the status word shall be returned in the response. All status words except '9000' and warning status words (i.e. '62xx' and '63xx') shall be interpreted as error status words."

This PR is an attempt to bring the handling of response APDUs in an SCP03 session in line with this part of the specification.  The previous behavior would throw an exception and terminate the session if the card returned an error in response to any command APDU inside the SCP03 RMAC session.