### PR TITLE
Fix LFDBH enum access modifier

### DIFF
--- a/library/src/main/java/pro/javacard/gp/GPData.java
+++ b/library/src/main/java/pro/javacard/gp/GPData.java
@@ -129,7 +129,7 @@ public final class GPData {
         }
     }
 
-    enum LFDBH {
+    public enum LFDBH {
         SHA1(0x01, "SHA-1"),
         SHA256(0x02, "SHA-256"),
         SHA384(0x03, "SHA-384"),


### PR DESCRIPTION
Make LFDBH public, otherwise library users cannot call GPSession.loadCapFile