### PR TITLE
Add an option to disable resetting card on disconnect

### DIFF
--- a/tool/src/main/java/pro/javacard/gp/GPCommandLineInterface.java
+++ b/tool/src/main/java/pro/javacard/gp/GPCommandLineInterface.java
@@ -47,6 +47,7 @@ abstract class GPCommandLineInterface {
     protected static OptionSpec<HexBytes> OPT_SECURE_APDU = parser.acceptsAll(Arrays.asList("s", "secure-apdu"), "Send raw APDU via SCP").withRequiredArg().ofType(HexBytes.class).describedAs("APDU");
     protected static OptionSpec<Void> OPT_FORCE = parser.acceptsAll(Arrays.asList("f", "force"), "Force operations");
     protected static OptionSpec<Void> OPT_SAD = parser.acceptsAll(Arrays.asList("F", "no-felix"), "Disable Felix mode DWIM");
+    protected static OptionSpec<Void> OPT_NO_RESET = parser.acceptsAll(Arrays.asList("R", "no-reset"), "Disable resetting card when disconnecting");
 
     // Applet loading operations
     protected static OptionSpec<File> OPT_CAP = parser.accepts("cap", "Use a CAP file as source").withRequiredArg().ofType(File.class).describedAs("capfile");

--- a/tool/src/main/java/pro/javacard/gp/GPCommandLineInterface.java
+++ b/tool/src/main/java/pro/javacard/gp/GPCommandLineInterface.java
@@ -47,7 +47,6 @@ abstract class GPCommandLineInterface {
     protected static OptionSpec<HexBytes> OPT_SECURE_APDU = parser.acceptsAll(Arrays.asList("s", "secure-apdu"), "Send raw APDU via SCP").withRequiredArg().ofType(HexBytes.class).describedAs("APDU");
     protected static OptionSpec<Void> OPT_FORCE = parser.acceptsAll(Arrays.asList("f", "force"), "Force operations");
     protected static OptionSpec<Void> OPT_SAD = parser.acceptsAll(Arrays.asList("F", "no-felix"), "Disable Felix mode DWIM");
-    protected static OptionSpec<Void> OPT_NO_RESET = parser.acceptsAll(Arrays.asList("R", "no-reset"), "Disable resetting card when disconnecting");
 
     // Applet loading operations
     protected static OptionSpec<File> OPT_CAP = parser.accepts("cap", "Use a CAP file as source").withRequiredArg().ofType(File.class).describedAs("capfile");

--- a/tool/src/main/java/pro/javacard/gp/GPTool.java
+++ b/tool/src/main/java/pro/javacard/gp/GPTool.java
@@ -122,6 +122,7 @@ public final class GPTool extends GPCommandLineInterface implements SimpleSmartC
     public static void main(String[] argv) {
         Card c = null;
         int ret = 1;
+        boolean resetOnDisconnect = true;
         try {
             OptionSet args = parseArguments(argv);
             setupLogging(args);
@@ -129,7 +130,9 @@ public final class GPTool extends GPCommandLineInterface implements SimpleSmartC
 
             if (onlyHasArg(args, OPT_VERSION))
                 System.exit(0);
-
+            if (args.has(OPT_NO_RESET)) {
+                resetOnDisconnect= false;
+            }
             TerminalManager terminalManager = TerminalManager.getDefault();
             List<PCSCReader> readers = TerminalManager.listPCSC(terminalManager.terminals().list(), null, false);
 
@@ -157,7 +160,7 @@ public final class GPTool extends GPCommandLineInterface implements SimpleSmartC
         } finally {
             if (c != null) {
                 try {
-                    c.disconnect(true);
+                    c.disconnect(resetOnDisconnect);
                 } catch (CardException e) {
                     // Warn or ignore
                 }

--- a/tool/src/main/java/pro/javacard/gp/GPTool.java
+++ b/tool/src/main/java/pro/javacard/gp/GPTool.java
@@ -66,6 +66,9 @@ public final class GPTool extends GPCommandLineInterface implements SimpleSmartC
     static final String ENV_GP_READER_IGNORE = "GP_READER_IGNORE";
     static final String ENV_GP_TRACE = "GP_TRACE";
 
+    static final String ENV_GP_PCSC_RESET = "GP_PCSC_RESET";
+    static final String PROP_GP_PCSC_RESET = "pro.javacard.gp.pcsc_reset";
+
     static void setupLogging(OptionSet args) {
         // Set up slf4j simple in a way that pleases us
         System.setProperty("org.slf4j.simpleLogger.showThreadName", "false");
@@ -130,14 +133,19 @@ public final class GPTool extends GPCommandLineInterface implements SimpleSmartC
 
             if (onlyHasArg(args, OPT_VERSION))
                 System.exit(0);
-            if (args.has(OPT_NO_RESET)) {
-                resetOnDisconnect= false;
-            }
             TerminalManager terminalManager = TerminalManager.getDefault();
             List<PCSCReader> readers = TerminalManager.listPCSC(terminalManager.terminals().list(), null, false);
 
             String useReader = args.hasArgument(OPT_READER) ? args.valueOf(OPT_READER) : System.getenv(ENV_GP_READER);
             String ignoreReader = System.getenv(ENV_GP_READER_IGNORE);
+
+            String pcscReset = System.getProperty(PROP_GP_PCSC_RESET);
+            if (pcscReset == null) {
+                pcscReset = System.getenv(ENV_GP_PCSC_RESET);
+            }
+            if ((pcscReset != null) && (pcscReset.equalsIgnoreCase("false") || pcscReset.equals("0"))) {
+                resetOnDisconnect = false;
+            }
 
             // FIXME: simplify
             Optional<CardTerminal> reader = TerminalManager.getLucky(TerminalManager.dwimify(readers, useReader, ignoreReader), terminalManager.terminals());

--- a/tool/src/main/java/pro/javacard/gp/GPTool.java
+++ b/tool/src/main/java/pro/javacard/gp/GPTool.java
@@ -67,7 +67,6 @@ public final class GPTool extends GPCommandLineInterface implements SimpleSmartC
     static final String ENV_GP_TRACE = "GP_TRACE";
 
     static final String ENV_GP_PCSC_RESET = "GP_PCSC_RESET";
-    static final String PROP_GP_PCSC_RESET = "pro.javacard.gp.pcsc_reset";
 
     static void setupLogging(OptionSet args) {
         // Set up slf4j simple in a way that pleases us
@@ -125,7 +124,7 @@ public final class GPTool extends GPCommandLineInterface implements SimpleSmartC
     public static void main(String[] argv) {
         Card c = null;
         int ret = 1;
-        boolean resetOnDisconnect = true;
+        boolean resetOnDisconnect = Boolean.parseBoolean(System.getenv().getOrDefault(ENV_GP_PCSC_RESET, "false"));
         try {
             OptionSet args = parseArguments(argv);
             setupLogging(args);
@@ -139,13 +138,7 @@ public final class GPTool extends GPCommandLineInterface implements SimpleSmartC
             String useReader = args.hasArgument(OPT_READER) ? args.valueOf(OPT_READER) : System.getenv(ENV_GP_READER);
             String ignoreReader = System.getenv(ENV_GP_READER_IGNORE);
 
-            String pcscReset = System.getProperty(PROP_GP_PCSC_RESET);
-            if (pcscReset == null) {
-                pcscReset = System.getenv(ENV_GP_PCSC_RESET);
-            }
-            if ((pcscReset != null) && (pcscReset.equalsIgnoreCase("false") || pcscReset.equals("0"))) {
-                resetOnDisconnect = false;
-            }
+
 
             // FIXME: simplify
             Optional<CardTerminal> reader = TerminalManager.getLucky(TerminalManager.dwimify(readers, useReader, ignoreReader), terminalManager.terminals());


### PR DESCRIPTION
Added the -R option to control whether card.disconnect() is called with true or false when shutting down. This can noticeably speed up the use of the CLI and is useful when repeatedly using the CLI and you do not need to reset the card between invocations.