### PR TITLE
Implement --store-p1 command line parameter

### DIFF
--- a/tool/src/main/java/pro/javacard/gp/GPCommandLineInterface.java
+++ b/tool/src/main/java/pro/javacard/gp/GPCommandLineInterface.java
@@ -126,6 +126,7 @@ abstract class GPCommandLineInterface {
     // Personalization and store data
     protected static OptionSpec<HexBytes> OPT_STORE_DATA = parser.accepts("store-data", "STORE DATA blob").withRequiredArg().ofType(HexBytes.class).describedAs("data");
     protected static OptionSpec<HexBytes> OPT_STORE_DATA_CHUNK = parser.accepts("store-data-chunk", "Send STORE DATA commands").withRequiredArg().ofType(HexBytes.class).describedAs("data");
+    protected static OptionSpec<HexBytes> OPT_STORE_P1 = parser.accepts("store-p1", "STORE DATA parameter P1 (example: 09)").withRequiredArg().ofType(HexBytes.class).describedAs("data");
 
     protected static OptionSpec<AID> OPT_MAKE_DEFAULT = parser.accepts("make-default", "Make AID the default").withRequiredArg().ofType(AID.class);
     protected static OptionSpec<AID> OPT_RENAME_ISD = parser.accepts("rename-isd", "Rename ISD").withRequiredArg().ofType(AID.class).describedAs("new AID");

--- a/tool/src/main/java/pro/javacard/gp/GPTool.java
+++ b/tool/src/main/java/pro/javacard/gp/GPTool.java
@@ -671,12 +671,24 @@ public final class GPTool extends GPCommandLineInterface implements SimpleSmartC
                 // --store-data <XX>
                 // This will split the data, if necessary
                 if (args.has(OPT_STORE_DATA)) {
+                    byte storeP1 = 0x01;
+
+                    if (args.has(OPT_STORE_P1)) {
+                        byte[] tmpP1 = args.valueOf(OPT_STORE_P1).v();
+
+                        if (tmpP1.length != 1) {
+                            System.err.println("Warning: ignoring --store-p1, expected only 1 byte.");
+                        } else {
+                            storeP1 = tmpP1[0];
+                        }
+                    }
+
                     List<byte[]> blobs = args.valuesOf(OPT_STORE_DATA).stream().map(HexBytes::value).collect(Collectors.toList());
                     for (byte[] blob : blobs) {
                         if (args.has(OPT_APPLET)) {
-                            gp.personalize(args.valueOf(OPT_APPLET), blob, 0x01);
+                            gp.personalize(args.valueOf(OPT_APPLET), blob, storeP1);
                         } else {
-                            gp.storeData(blob, 0x1);
+                            gp.storeData(blob, storeP1);
                         }
                     }
                 }


### PR DESCRIPTION
Sometimes we need to control the P1 parameter when executing STORE DATA command through CLI. This happens especially if we want to use non-default BER-TLV data format and this needs to be indicated in P1 parameter. Right now there is no way to control P1 value through `--store-data` CLI command. So my proposition is to add `--store-p1` additional parameter which allows to control the P1 value.

I've tested the change and it seems to work correctly.