### PR TITLE
Fix support of 192 bits AES keys

### DIFF
--- a/library/src/main/java/pro/javacard/gp/GPSession.java
+++ b/library/src/main/java/pro/javacard/gp/GPSession.java
@@ -914,8 +914,8 @@ public class GPSession {
             final var baos = new ByteArrayOutputStream();
             if (type == GPKey.AES) {
                 // Pad with random
-                final var n = other.length % 16 + 1;
-                final byte[] plaintext = GPCrypto.random(n * other.length);
+                final var n = 16 * ((other.length + 15) / 16);
+                final byte[] plaintext = GPCrypto.random(n);
                 System.arraycopy(other, 0, plaintext, 0, other.length);
 
                 final var cgram = dek.encrypt(plaintext, sessionContext);

--- a/library/src/main/java/pro/javacard/gp/keys/PlaintextKeys.java
+++ b/library/src/main/java/pro/javacard/gp/keys/PlaintextKeys.java
@@ -287,8 +287,8 @@ public final class PlaintextKeys extends GPCardKeys {
                 logger.debug("Encrypting {} value (KCV={}) with DEK (KCV={})", p, HexUtils.bin2hex(other.kcv(p)), HexUtils.bin2hex(kcv(KeyPurpose.DEK)));
                 final var otherkey = other.cardKeys.get(p);
                 // Pad with random
-                final var n = otherkey.length % 16 + 1;
-                final byte[] plaintext = GPCrypto.random(n * otherkey.length);
+                final var n = 16 * ((otherkey.length + 15) / 16);
+                final byte[] plaintext = GPCrypto.random(n);
                 System.arraycopy(otherkey, 0, plaintext, 0, otherkey.length);
                 // encrypt
                 return GPCrypto.aes_cbc(plaintext, cardKeys.get(KeyPurpose.DEK), new byte[16]);

--- a/nextgen/src/main/java/pro/javacard/gp/ng/PlaintextCardKeys.java
+++ b/nextgen/src/main/java/pro/javacard/gp/ng/PlaintextCardKeys.java
@@ -229,8 +229,8 @@ public final class PlaintextCardKeys implements CardKeys, AutoCloseable {
                 }
                 case SCP03 -> {
                     // Pad with random for AES key wrapping
-                    var n = keyValue.length % 16 + 1;
-                    var plaintext = GPCrypto.random(n * keyValue.length);
+                    var n = 16 * ((keyValue.length + 15) / 16);
+                    var plaintext = GPCrypto.random(n);
                     System.arraycopy(keyValue, 0, plaintext, 0, keyValue.length);
                     yield GPCrypto.aes_cbc(plaintext, dek, new byte[16]);
                 }


### PR DESCRIPTION
This fixes usage of 192 bits AES keys by fixing the padding calculation for when plaintext keys are not a multiple of 16 bytes in length